### PR TITLE
Don't use .npmignore - Use "files" in package.json.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-.git
-.nyc_output
-.travis.yml
-test
-coverage
-seymour.png

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "author": "Darryl Pogue <darryl@dpogue.ca>",
   "contributors": [
-    "Sam Evanuk <samevanuk@gmail.com>"
+    "Sam Evanuk <samevanuk@gmail.com>",
+    "Infacto <infacto@tuta.io>"
   ],
   "license": "Apache-2.0",
   "main": "src/seymour.js",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "license": "Apache-2.0",
   "main": "src/seymour.js",
   "bin": "bin/seymour",
+  "files": [
+    "bin",
+    "src"
+  ],
   "scripts": {
     "lint": "eslint .",
     "test": "tap test/*.js",


### PR DESCRIPTION
Fixes https://github.com/dpogue/seymour/issues/27

From (old package content):

```text
seymour
|= .github
|  \= workflows
|     \- ci.yml
|= bin
|  |- seymour
|  \- seymour.cmd
|= src
|  \- seymour.js
|- .editorconfig
|- .eslintrc
|- CHANGELOG.md
|- CODE_OF_CONDUCT.md
|- LICENCE
|- package.json
\- README.md
```

To (new package content with this commit):

```text
package
|= src
|  \- seymour.js
|= bin
|  |- seymour
|  \- seymour.cmd
|- CHANGELOG.md
|- LICENCE
|- package.json
\- README.md
```
